### PR TITLE
Fixed "TypeError: argument of type 'NoneType' is not iterable"

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -105,16 +105,16 @@ def sanity_checks(service, instance=None):
     if not clean and not build and not run and not ssh and not ip:
         raise Exception('Unknown caller (got "{}")'.format(caller))
 
-    # Check not valid chars in service name TODO: Use a regex suitable for a hostname
-    if '_' in service:
-        abort('Character "_" is not allowed in a service name (got "{}")'.format(service)) 
-
     # Check service name 
     if not service:
         if clean:
             abort('You must provide the service name or use the magic words "all" or "reallyall"') 
         else:
             abort('You must provide the service name or use the magic word "all"')
+    
+    # Check not valid chars in service name TODO: Use a regex suitable for a hostname
+    if '_' in service:
+        abort('Character "_" is not allowed in a service name (got "{}")'.format(service)) 
     
     # Check instance name     
     if not instance:


### PR DESCRIPTION
When calling **dockerops ip** from command line, the following exception was not caught

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/fabric/main.py", line 743, in main
*args, **kwargs
  File "/usr/lib/python2.7/dist-packages/fabric/tasks.py", line 424, in execute
results['<local-only>'] = task.run(*args, **new_kwargs)
  File "/usr/lib/python2.7/dist-packages/fabric/tasks.py", line 174, in run
return self.wrapped(*args, **kwargs)
  File "/home/ale/haykle/DockerOps/fabfile.py", line 1302, in ip
(service, instance) = sanity_checks(service,instance)
  File "/home/ale/haykle/DockerOps/fabfile.py", line 109, in sanity_checks
if '_' in service:
TypeError: argument of type 'NoneType' is not iterable
```

Changed the order of operations (first check service name, then name content).
An error message is emitted.
